### PR TITLE
types: return NotImplemented from __eq__ for type errors

### DIFF
--- a/asyncvarlink/types.py
+++ b/asyncvarlink/types.py
@@ -193,7 +193,7 @@ class FileDescriptor:
         try:
             otherfileno = get_fileno(other)
         except TypeError:
-            return False
+            return NotImplemented
         except ValueError:
             return selffileno is None
         return selffileno == otherfileno
@@ -353,7 +353,7 @@ class FileDescriptorArray(FutureCounted):
     @override
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, FileDescriptorArray):
-            return False
+            return NotImplemented
         if len(self._by_position) != len(other._by_position):
             return False
         return all(


### PR DESCRIPTION
This is [somewhat more conventional](https://docs.python.org/3/reference/datamodel.html#object.__eq__) for pairs of arguments that are of types not handled by the comparison method.  In practice it means that the interpreter may fall back to trying the reflected operation on the other operand.