### PR TITLE
varlinkmethod: allow overriding the return type

### DIFF
--- a/asyncvarlink/interface.py
+++ b/asyncvarlink/interface.py
@@ -149,11 +149,19 @@ class _VarlinkMethodDecorator(typing.Protocol):
     ) -> collections.abc.Callable[_P, _MethodResultType]: ...
 
 
+class _NotGiven:
+    pass
+
+
+_notgiven = _NotGiven()
+
+
 @typing.overload
 def varlinkmethod(
     function: collections.abc.Callable[_P, collections.abc.AsyncIterator[_R]],
     *,
     return_parameter: str | None = None,
+    return_type: type | _NotGiven = _notgiven,
     delay_generator: bool = True,
     allow_foreign: bool = False,
 ) -> collections.abc.Callable[
@@ -166,6 +174,7 @@ def varlinkmethod(
     function: collections.abc.Callable[_P, collections.abc.Iterator[_R]],
     *,
     return_parameter: str | None = None,
+    return_type: type | _NotGiven = _notgiven,
     delay_generator: bool = True,
     allow_foreign: bool = False,
 ) -> collections.abc.Callable[
@@ -178,6 +187,7 @@ def varlinkmethod(
     function: collections.abc.Callable[_P, collections.abc.Awaitable[_R]],
     *,
     return_parameter: str | None = None,
+    return_type: type | _NotGiven = _notgiven,
     delay_generator: bool = True,
     allow_foreign: bool = False,
 ) -> collections.abc.Callable[
@@ -190,6 +200,7 @@ def varlinkmethod(
     function: collections.abc.Callable[_P, _R],
     *,
     return_parameter: str | None = None,
+    return_type: type | _NotGiven = _notgiven,
     delay_generator: bool = True,
     allow_foreign: bool = False,
 ) -> collections.abc.Callable[_P, _MethodResultType]: ...
@@ -199,6 +210,7 @@ def varlinkmethod(
 def varlinkmethod(
     *,
     return_parameter: str | None = None,
+    return_type: type | _NotGiven = _notgiven,
     delay_generator: bool = True,
     allow_foreign: bool = False,
 ) -> _VarlinkMethodDecorator: ...
@@ -211,6 +223,7 @@ def varlinkmethod(
     function: collections.abc.Callable[_P, _R] | None = None,
     *,
     return_parameter: str | None = None,
+    return_type: type | _NotGiven = _notgiven,
     delay_generator: bool = True,
     allow_foreign: bool = False,
 ) -> (
@@ -228,6 +241,12 @@ def varlinkmethod(
     AnnotatedResult instances. If return_parameter is None, it may produce a
     dict and a bare value to be wrapped in a dict with return_parameter as key
     otherwise.
+
+    To enable implementations to return or yield AnnotatedResult objects, they
+    may be annotated as returning AnnotatedResult or generators thereof and
+    pass the type annotation used for introspection via the return_type
+    parameter. Note that the return_type should be the element type for
+    generators.
 
     If the function is a generator (async or not), AnnotatedResult instances
     are forwarded immediately. They must correctly indicate whether the
@@ -256,9 +275,9 @@ def varlinkmethod(
             raise RuntimeError(
                 "first argument of a method should be named self"
             )
-        return_type = signature.return_annotation
+        return_pytype = signature.return_annotation
         more = False
-        ret_origin = typing.get_origin(return_type)
+        ret_origin = typing.get_origin(return_pytype)
         if ret_origin is not None and issubclass(
             ret_origin,
             (
@@ -267,24 +286,26 @@ def varlinkmethod(
                 else collections.abc.Iterator
             ),
         ):
-            return_type = typing.get_args(return_type)[0]
+            return_pytype = typing.get_args(return_pytype)[0]
             more = True
         return_vtype: VarlinkType
         make_result: collections.abc.Callable[[_R], AnnotatedResult]
-        if return_type is None:
+        if return_type is not _notgiven:
+            return_pytype = return_type
+        if return_pytype is None:
             return_vtype = ObjectVarlinkType({})
 
             def make_result(_result: _R) -> AnnotatedResult:
                 return AnnotatedResult({})
 
         else:
-            return_vtype = VarlinkType.from_type_annotation(return_type)
+            return_vtype = VarlinkType.from_type_annotation(return_pytype)
             if (not allow_foreign) and any(
                 isinstance(vt, ForeignVarlinkType)
                 for vt in return_vtype.traverse()
             ):
                 raise TypeError(
-                    f"Use of foreign not enabled for return type {return_type!r}"
+                    f"Use of foreign not enabled for return type {return_pytype!r}"
                 )
             if return_parameter is not None:
                 return_vtype = ObjectVarlinkType(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -40,16 +40,16 @@ class TestInterface(unittest.TestCase):
             def simple(self) -> ResultWrapper:
                 return res("simple")
 
-            @varlinkmethod
-            def annotated(self) -> ResultWrapper:
+            @varlinkmethod(return_type=ResultWrapper)
+            def annotated(self) -> AnnotatedResult:
                 return AnnotatedResult(res("annotated"))
 
             @varlinkmethod(return_parameter="result")
             def named(self) -> str:
                 return "named"
 
-            @varlinkmethod(return_parameter="result")
-            def annotated_named(self) -> str:
+            @varlinkmethod(return_parameter="result", return_type=str)
+            def annotated_named(self) -> AnnotatedResult:
                 return AnnotatedResult(res("annotated_named"))
 
             @varlinkmethod(return_parameter="result")
@@ -60,8 +60,10 @@ class TestInterface(unittest.TestCase):
             def error(self) -> ResultWrapper:
                 raise ExpectedError()
 
-            @varlinkmethod
-            def gen(self) -> collections.abc.Iterator[ResultWrapper]:
+            @varlinkmethod(return_type=ResultWrapper)
+            def gen(
+                self,
+            ) -> collections.abc.Iterator[AnnotatedResult | ResultWrapper]:
                 self.gen_state = 0
                 yield AnnotatedResult(res("gen0"), continues=True)
                 self.gen_state = 1
@@ -77,8 +79,14 @@ class TestInterface(unittest.TestCase):
                 self.genr_state = 1
                 raise LastResult("genr1")
 
-            @varlinkmethod(delay_generator=False, return_parameter="result")
-            def gen_immediate(self) -> collections.abc.Iterator[str]:
+            @varlinkmethod(
+                delay_generator=False,
+                return_parameter="result",
+                return_type=str,
+            )
+            def gen_immediate(
+                self,
+            ) -> collections.abc.Iterator[AnnotatedResult | str]:
                 self.geni_state = 0
                 yield AnnotatedResult(res("geni0"), continues=True)
                 self.geni_state = 1
@@ -169,22 +177,24 @@ class TestAsyncInterface(unittest.IsolatedAsyncioTestCase):
             async def simple(self) -> ResultWrapper:
                 return res("simple")
 
-            @varlinkmethod
-            async def annotated(self) -> ResultWrapper:
+            @varlinkmethod(return_type=ResultWrapper)
+            async def annotated(self) -> AnnotatedResult:
                 return AnnotatedResult(res("annotated"))
 
             @varlinkmethod(return_parameter="result")
             async def named(self) -> str:
                 return "named"
 
-            @varlinkmethod(return_parameter="result")
-            async def annotated_named(self) -> str:
+            @varlinkmethod(return_parameter="result", return_type=str)
+            async def annotated_named(self) -> AnnotatedResult:
                 return AnnotatedResult(res("annotated_named"))
 
-            @varlinkmethod
+            @varlinkmethod(return_type=ResultWrapper)
             async def gen(
                 self,
-            ) -> collections.abc.AsyncIterator[ResultWrapper]:
+            ) -> collections.abc.AsyncIterator[
+                AnnotatedResult | ResultWrapper
+            ]:
                 self.gen_state = 0
                 yield AnnotatedResult(res("gen0"), continues=True)
                 self.gen_state = 1
@@ -200,10 +210,14 @@ class TestAsyncInterface(unittest.IsolatedAsyncioTestCase):
                 self.genr_state = 1
                 raise LastResult("genr1")
 
-            @varlinkmethod(delay_generator=False, return_parameter="result")
+            @varlinkmethod(
+                delay_generator=False,
+                return_parameter="result",
+                return_type=str,
+            )
             async def gen_immediate(
                 self,
-            ) -> collections.abc.AsyncIterator[str]:
+            ) -> collections.abc.AsyncIterator[AnnotatedResult | str]:
                 self.geni_state = 0
                 yield AnnotatedResult(res("geni0"), continues=True)
                 self.geni_state = 1


### PR DESCRIPTION
The varlinkmethod decorator consumes the type annotation of the returned function, but it also supports elements of type AnnotatedResult being returned even when a different type is declared. This tends to work badly with type checkers such as mypy. To make this more useful, allow overriding the consumed type annotation on the decorator. Thus methods may actually declare returning AnnotatedResult without breaking introspection.

Suggested-by: Colin Watson <cjwatson@debian.org>